### PR TITLE
Fix a few edge cases due to missing ast node types

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -108,8 +108,15 @@ func (nom namedOccurrenceMap) checkStatement(stmt ast.Stmt, ifPos token.Pos) {
 		for _, el := range v.Body.List {
 			nom.checkStatement(el, v.If)
 		}
+		if elseBlock, ok := v.Else.(*ast.BlockStmt); ok {
+			for _, el := range elseBlock.List {
+				nom.checkStatement(el, v.If)
+			}
+		}
 
 		switch cond := v.Cond.(type) {
+		case *ast.UnaryExpr:
+			nom.checkExpression(cond.X, v.If)
 		case *ast.BinaryExpr:
 			nom.checkExpression(cond.X, v.If)
 			nom.checkExpression(cond.Y, v.If)

--- a/pkg/analyzer/occurrences.go
+++ b/pkg/analyzer/occurrences.go
@@ -193,6 +193,13 @@ func (nom namedOccurrenceMap) addFromCondition(stmt *ast.IfStmt) {
 				nom.addFromIdent(stmt.If, e.X)
 			}
 		}
+	case *ast.UnaryExpr:
+		switch e := v.X.(type) {
+		case *ast.Ident:
+			nom.addFromIdent(stmt.If, e)
+		case *ast.SelectorExpr:
+			nom.addFromIdent(stmt.If, e.X)
+		}
 	case *ast.Ident:
 		nom.addFromIdent(stmt.If, v)
 	case *ast.CallExpr:

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -77,6 +77,14 @@ func notUsed_DifferentVarsWithSameName_NotOK() {
 	noOp2(b)
 }
 
+func notUsed_UnaryOpIfStatement_NotOK() {
+	shouldRun := false // want "variable '.+' is only used in the if-statement"
+	if !shouldRun {
+		return
+	}
+	noOp1(0)
+}
+
 // Cases where short syntax SHOULD NOT be used AND IS NOT used.
 
 func notUsed_DeferStmt_OK() {
@@ -574,4 +582,28 @@ func notUsed_ReturnInSlice_Selector_OK(d dummyType) ([]interface{}, interface{})
 		return nil, v.interf
 	}
 	return []interface{}{v.interf}, nil
+}
+
+func notUsed_Multiple_If_Statements_OK() {
+	shouldRun := false
+	if shouldRun {
+		noOp1(0)
+	}
+	if !shouldRun {
+		return
+	}
+	noOp2(0)
+}
+
+func notUsed_Also_Used_In_Else_Body_OK() {
+	x := 0
+	if x > 0 {
+		noOp1(0)
+	}
+
+	if y := getInt(0); y > 0 {
+		noOp1(y)
+	} else {
+		noOp1(x)
+	}
 }


### PR DESCRIPTION
* Traverse Unary expressions in if statements
* Traverse else blocks

This fixes both false positives and negatives resulting from previously ignoring uses of variables in the above node types.  I believe this should fix both issues raised on #23.